### PR TITLE
SystemUI: Fix duplicate charging status on lockscreen and implement Screen off FOD

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -3680,7 +3680,7 @@ public final class Settings {
          * @hide
          */
         public static final int END_BUTTON_BEHAVIOR_HOME = 0x1;
-
+    
         /**
          * END_BUTTON_BEHAVIOR value for "go to sleep".
          * @hide
@@ -4896,6 +4896,12 @@ public final class Settings {
          * @hide
          */
         public static final String QS_TILE_TITLE_VISIBILITY = "qs_tile_title_visibility";
+    
+        /**
+          * Screen-off FOD
+          * @hide
+          */
+         public static final String FOD_GESTURE = "fod_gesture";
 
         /**
          * IMPORTANT: If you add a new public settings you also have to add it to

--- a/packages/SettingsProvider/src/android/provider/settings/validators/SystemSettingsValidators.java
+++ b/packages/SettingsProvider/src/android/provider/settings/validators/SystemSettingsValidators.java
@@ -223,5 +223,6 @@ public class SystemSettingsValidators {
                     }
                 });
         VALIDATORS.put(System.SCREENSHOT_SOUND, BOOLEAN_VALIDATOR);
+        VALIDATORS.put(System.FOD_GESTURE, BOOLEAN_VALIDATOR);
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -18,6 +18,7 @@ package com.android.systemui.biometrics;
 
 import android.app.admin.DevicePolicyManager;
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.content.ContentResolver;
 import android.content.res.Resources;
@@ -34,7 +35,9 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.UserHandle;
 import android.os.Looper;
+import android.os.PowerManager;
 import android.os.RemoteException;
+import android.os.SystemClock;
 import android.provider.Settings;
 import android.view.Display;
 import android.view.Gravity;
@@ -52,6 +55,7 @@ import com.android.keyguard.KeyguardUpdateMonitorCallback;
 import com.android.settingslib.utils.ThreadUtils;
 import com.android.systemui.Dependency;
 import com.android.systemui.R;
+import com.android.systemui.tuner.TunerService;
 
 import vendor.lineage.biometrics.fingerprint.inscreen.V1_0.IFingerprintInscreen;
 import vendor.lineage.biometrics.fingerprint.inscreen.V1_0.IFingerprintInscreenCallback;
@@ -60,7 +64,9 @@ import java.util.NoSuchElementException;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public class FODCircleView extends ImageView {
+public class FODCircleView extends ImageView implements TunerService.Tunable {
+    private static final String DOZE_INTENT = "com.android.systemui.doze.pulse";
+    private static final String FOD_GESTURE = "system:" + Settings.System.FOD_GESTURE;
     private static final int FADE_ANIM_DURATION = 250;
 
     private final int mPositionX;
@@ -87,6 +93,13 @@ public class FODCircleView extends ImageView {
     private boolean mIsDreaming;
     private boolean mIsKeyguard;
     private boolean mTouchedOutside;
+    private boolean mDozeEnabled;
+    private boolean mFodGestureEnable;
+    private boolean mPressPending;
+    private boolean mScreenTurnedOn;
+    
+    private PowerManager mPowerManager;
+    private PowerManager.WakeLock mWakeLock;
 
     private Handler mHandler;
 
@@ -107,13 +120,26 @@ public class FODCircleView extends ImageView {
                 // Keyguard requires strong authentication (not biometrics)
                 return;
             }
-
-            mHandler.post(() -> showCircle());
+            if (mFodGestureEnable && !mScreenTurnedOn) {
+                if (mDozeEnabled) {
+                    mHandler.post(() -> mContext.sendBroadcast(new Intent(DOZE_INTENT)));
+                } else {
+                    mWakeLock.acquire(3000);
+                    mHandler.post(() -> mPowerManager.wakeUp(SystemClock.uptimeMillis(),
+                        PowerManager.WAKE_REASON_GESTURE, FODCircleView.class.getSimpleName()));
+                }
+                mPressPending = true;
+            } else {
+                mHandler.post(() -> showCircle());
+            }
         }
 
         @Override
         public void onFingerUp() {
             mHandler.post(() -> hideCircle());
+            if (mPressPending) {
+                mPressPending = false;
+            }
         }
     };
 
@@ -194,7 +220,12 @@ public class FODCircleView extends ImageView {
 
         @Override
         public void onScreenTurnedOff() {
-            hide();
+            mScreenTurnedOn = false;
+            if (!mFodGestureEnable) {
+                hide();
+            } else {
+                hideCircle();
+            }
         }
 
         @Override
@@ -206,9 +237,15 @@ public class FODCircleView extends ImageView {
 
         @Override
         public void onScreenTurnedOn() {
-            if (mUpdateMonitor.isFingerprintDetectionRunning()) {
+        	mScreenTurnedOn = true;
+            if (mUpdateMonitor.isFingerprintDetectionRunning() && !mFodGestureEnable) {
                 show();
             }
+            if (mPressPending) {
+                mHandler.post(() -> showCircle());
+                mPressPending = false;
+            }
+            mScreenTurnedOn = true;
         }
     };
 
@@ -268,6 +305,10 @@ public class FODCircleView extends ImageView {
 
         mPaintFingerprintBackground.setColor(res.getColor(R.color.config_fodColorBackground));
         mPaintFingerprintBackground.setAntiAlias(true);
+        
+        mPowerManager = context.getSystemService(PowerManager.class);
+        mWakeLock = mPowerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
+                 FODCircleView.class.getSimpleName());
 
         mWindowManager = context.getSystemService(WindowManager.class);
 
@@ -317,11 +358,12 @@ public class FODCircleView extends ImageView {
         hide();
 
         mLockPatternUtils = new LockPatternUtils(mContext);
-
+    	mFODAnimation = new FODAnimation(context, mPositionX, mPositionY);
+    
         mUpdateMonitor = Dependency.get(KeyguardUpdateMonitor.class);
         mUpdateMonitor.registerCallback(mMonitorCallback);
-
-        mFODAnimation = new FODAnimation(context, mPositionX, mPositionY);
+		Dependency.get(TunerService.class).addTunable(this, FOD_GESTURE,
+                Settings.Secure.DOZE_ENABLED);
     }
 
     @Override
@@ -454,7 +496,7 @@ public class FODCircleView extends ImageView {
             return;
         }
 
-        if (!mUpdateMonitor.isScreenOn()) {
+        if (!mUpdateMonitor.isScreenOn() && !mFodGestureEnable) {
             // Keyguard is shown just after screen turning off
             return;
         }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
@@ -469,15 +469,7 @@ public class KeyguardIndicationController implements StateListener,
         if (!mKeyguardUpdateMonitor.isUserUnlocked(userId)) {
             mTextView.switchIndication(com.android.internal.R.string.lockscreen_storage_locked);
         } else if (!TextUtils.isEmpty(mTransientIndication)) {
-            if (powerIndication != null && !mTransientIndication.equals(powerIndication)) {
-                String indication = mContext.getResources().getString(
-                                R.string.keyguard_indication_trust_unlocked_plugged_in,
-                                mTransientIndication, powerIndication);
-                mTextView.switchIndication(indication);
-                hideIndication = !mBatteryPresent;
-            } else {
-                mTextView.switchIndication(mTransientIndication);
-            }
+            mTextView.switchIndication(mTransientIndication);
             isError = mTransientTextIsError;
         } else if (!TextUtils.isEmpty(trustGrantedIndication)
                 && mKeyguardUpdateMonitor.getUserHasTrust(userId)) {


### PR DESCRIPTION
Sometimes when a device is charging and user is on lock screen, duplicate charging status is shown.
To fix that, we don't need to append the charging status to if there is a transient notification.